### PR TITLE
use the right html-minifier

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const htmlmin = require("html-minifier");
+const htmlmin = require("html-minifier-terser");
 
 module.exports = function(eleventyConfig) {
 


### PR DESCRIPTION
the last dependency update changed the html minifier. It needs to be imported with its new name in eleventy.js